### PR TITLE
5 player game: only chancellor is ineligible due to term limits

### DIFF
--- a/server/discard.js
+++ b/server/discard.js
@@ -105,8 +105,8 @@ Meteor.methods({
         update.currentPresident = (room.currentPresident + 1) % _.size(room.players);
         update.currentChancellor = -1;
 
-        // if only 3 players are alive, only last chanchellor is ineligible to be next chan
-        if (room.alive <= 3) {
+        // if only 5 players are alive, only last chanchellor is ineligible to be next chan
+        if (room.alive <= 5) {
           update.ruledout = [
           room.players[room.currentChancellor].playerId ];
         } else {


### PR DESCRIPTION
## Problem
Currently, in a 5-player game, president can't be chancellor due to term limits, wherein the rules say

> If there are only five players left in the
game, only the last elected Chancellor is
ineligible to be Chancellor Candidate; the
last President may be nominated.

https://secrethitler.com/assets/Secret_Hitler_Rules.pdf 

## Solution
Change the 3 to a 5.

## Test Coverage
It's not great, but this PR doesn't make it worse.